### PR TITLE
Add `label` option to badges to change the displayed text

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Show off your Play Store™ app's downloads and rating in your repo
 | `fallback` | Fallback text for version badge when version is unavailable | `Varies` | `&fallback=Unknown` |
 | `country` | Country code | `us` or request origin | `&country=in` |
 | `theme` | Theme for the card | `light` | `&theme=dark` |
+| `label` | Text to show in the badge | `Downloads`/`Ratings`/`Version` | `&label=Installs` |
 
 ## Credits
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,9 @@ app.get('/app/details', async (c) => {
     return c.json(appDetails)
 })
 
-// GET /badge/downloads?id=<appId>&pretty&country=<countryCode>
+// GET /badge/downloads?id=<appId>&pretty&country=<countryCode>&label=<label>
 app.get('/badge/downloads', async (c) => {
-    const {id: appId, pretty, country} = c.req.query()
+    const {id: appId, pretty, country, label} = c.req.query()
     const isPretty = pretty !== undefined
     const countryCode = findCountryCode(
       country,
@@ -56,14 +56,14 @@ app.get('/badge/downloads', async (c) => {
 
     c.header('Content-Type', 'image/svg+xml')
     return c.body(shieldsBadge({
-        label: 'Downloads',
+        label: label ?? 'Downloads',
         status: `${isPretty ? compactNumberFormatter.format(Number(appDetails.maxInstalls)) : appDetails.maxInstalls}`,
     }))
 })
 
-// GET /badge/ratings?id=<appId>&pretty&country=<countryCode>
+// GET /badge/ratings?id=<appId>&pretty&country=<countryCode>&label=<label>
 app.get('/badge/ratings', async (c) => {
-    const {id: appId, pretty, country} = c.req.query()
+    const {id: appId, pretty, country, label} = c.req.query()
     const isPretty = pretty !== undefined
     const countryCode = findCountryCode(
       country,
@@ -78,14 +78,14 @@ app.get('/badge/ratings', async (c) => {
 
     c.header('Content-Type', 'image/svg+xml')
     return c.body(shieldsBadge({
-        label: 'Ratings',
+        label: label ?? 'Ratings',
         status: isPretty ? makeStars(Number(appDetails.score)) : `${appDetails.scoreText ?? 0}/5 (${appDetails.ratings ?? 0})`,
     }))
 })
 
-// GET /badge/version?id=<appId>&fallback=<fallbackText>&country=<countryCode>
+// GET /badge/version?id=<appId>&fallback=<fallbackText>&country=<countryCode>&label=<label>
 app.get('/badge/version', async (c) => {
-    const {id: appId, fallback, country} = c.req.query()
+    const {id: appId, fallback, country, label} = c.req.query()
     const countryCode = findCountryCode(
       country,
       c.req.raw.cf?.country as string | undefined
@@ -99,7 +99,7 @@ app.get('/badge/version', async (c) => {
 
     c.header('Content-Type', 'image/svg+xml')
     return c.body(shieldsBadge({
-        label: 'Version',
+        label: label ?? 'Version',
         status: appDetails.version ?? (fallback ?? 'Varies'),
     }))
 })


### PR DESCRIPTION
This PR allows changing the text that is displayed in badges.

I would like to use this service to show the total download count for our Android application. We currently have badges for github and flathub downloads, and they read as `GitHub Downloads` and `Flathub Downloads`. However, the android badge would read as `Downloads` which doesn't follow the same style as the other badges. This PR would allow me to change the label to `Play Store Downloads`.

This change is backwards compatible, as not setting the `label` parameter uses the previous default text.